### PR TITLE
refactor: Split UI using luckypot

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -89,6 +89,25 @@ files = [
 license = ["ukkonen"]
 
 [[package]]
+name = "luckypot"
+version = "0.1.0"
+description = "Another pygame engine. It might be what you need, if you're lucky to be called Diego."
+optional = false
+python-versions = "^3.9"
+files = []
+develop = false
+
+[package.dependencies]
+numpy = "^2.0.1"
+pygame-ce = "^2.5.0"
+
+[package.source]
+type = "git"
+url = "https://github.com/ddorn/luckypot.git"
+reference = "HEAD"
+resolved_reference = "fbf22609e8c98c6963c306ee4b338e0e46c6bf65"
+
+[[package]]
 name = "macholib"
 version = "1.16.3"
 description = "Mach-O header analysis and editing"
@@ -149,6 +168,60 @@ files = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.0.1"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "numpy-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0fbb536eac80e27a2793ffd787895242b7f18ef792563d742c2d673bfcb75134"},
+    {file = "numpy-2.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:69ff563d43c69b1baba77af455dd0a839df8d25e8590e79c90fcbe1499ebde42"},
+    {file = "numpy-2.0.1-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:1b902ce0e0a5bb7704556a217c4f63a7974f8f43e090aff03fcf262e0b135e02"},
+    {file = "numpy-2.0.1-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:f1659887361a7151f89e79b276ed8dff3d75877df906328f14d8bb40bb4f5101"},
+    {file = "numpy-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4658c398d65d1b25e1760de3157011a80375da861709abd7cef3bad65d6543f9"},
+    {file = "numpy-2.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4127d4303b9ac9f94ca0441138acead39928938660ca58329fe156f84b9f3015"},
+    {file = "numpy-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e5eeca8067ad04bc8a2a8731183d51d7cbaac66d86085d5f4766ee6bf19c7f87"},
+    {file = "numpy-2.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9adbd9bb520c866e1bfd7e10e1880a1f7749f1f6e5017686a5fbb9b72cf69f82"},
+    {file = "numpy-2.0.1-cp310-cp310-win32.whl", hash = "sha256:7b9853803278db3bdcc6cd5beca37815b133e9e77ff3d4733c247414e78eb8d1"},
+    {file = "numpy-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:81b0893a39bc5b865b8bf89e9ad7807e16717f19868e9d234bdaf9b1f1393868"},
+    {file = "numpy-2.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:75b4e316c5902d8163ef9d423b1c3f2f6252226d1aa5cd8a0a03a7d01ffc6268"},
+    {file = "numpy-2.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6e4eeb6eb2fced786e32e6d8df9e755ce5be920d17f7ce00bc38fcde8ccdbf9e"},
+    {file = "numpy-2.0.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a1e01dcaab205fbece13c1410253a9eea1b1c9b61d237b6fa59bcc46e8e89343"},
+    {file = "numpy-2.0.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:a8fc2de81ad835d999113ddf87d1ea2b0f4704cbd947c948d2f5513deafe5a7b"},
+    {file = "numpy-2.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5a3d94942c331dd4e0e1147f7a8699a4aa47dffc11bf8a1523c12af8b2e91bbe"},
+    {file = "numpy-2.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15eb4eca47d36ec3f78cde0a3a2ee24cf05ca7396ef808dda2c0ddad7c2bde67"},
+    {file = "numpy-2.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:b83e16a5511d1b1f8a88cbabb1a6f6a499f82c062a4251892d9ad5d609863fb7"},
+    {file = "numpy-2.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1f87fec1f9bc1efd23f4227becff04bd0e979e23ca50cc92ec88b38489db3b55"},
+    {file = "numpy-2.0.1-cp311-cp311-win32.whl", hash = "sha256:36d3a9405fd7c511804dc56fc32974fa5533bdeb3cd1604d6b8ff1d292b819c4"},
+    {file = "numpy-2.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:08458fbf403bff5e2b45f08eda195d4b0c9b35682311da5a5a0a0925b11b9bd8"},
+    {file = "numpy-2.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:6bf4e6f4a2a2e26655717a1983ef6324f2664d7011f6ef7482e8c0b3d51e82ac"},
+    {file = "numpy-2.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d6fddc5fe258d3328cd8e3d7d3e02234c5d70e01ebe377a6ab92adb14039cb4"},
+    {file = "numpy-2.0.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:5daab361be6ddeb299a918a7c0864fa8618af66019138263247af405018b04e1"},
+    {file = "numpy-2.0.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:ea2326a4dca88e4a274ba3a4405eb6c6467d3ffbd8c7d38632502eaae3820587"},
+    {file = "numpy-2.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:529af13c5f4b7a932fb0e1911d3a75da204eff023ee5e0e79c1751564221a5c8"},
+    {file = "numpy-2.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6790654cb13eab303d8402354fabd47472b24635700f631f041bd0b65e37298a"},
+    {file = "numpy-2.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:cbab9fc9c391700e3e1287666dfd82d8666d10e69a6c4a09ab97574c0b7ee0a7"},
+    {file = "numpy-2.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:99d0d92a5e3613c33a5f01db206a33f8fdf3d71f2912b0de1739894668b7a93b"},
+    {file = "numpy-2.0.1-cp312-cp312-win32.whl", hash = "sha256:173a00b9995f73b79eb0191129f2455f1e34c203f559dd118636858cc452a1bf"},
+    {file = "numpy-2.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:bb2124fdc6e62baae159ebcfa368708867eb56806804d005860b6007388df171"},
+    {file = "numpy-2.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bfc085b28d62ff4009364e7ca34b80a9a080cbd97c2c0630bb5f7f770dae9414"},
+    {file = "numpy-2.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8fae4ebbf95a179c1156fab0b142b74e4ba4204c87bde8d3d8b6f9c34c5825ef"},
+    {file = "numpy-2.0.1-cp39-cp39-macosx_14_0_arm64.whl", hash = "sha256:72dc22e9ec8f6eaa206deb1b1355eb2e253899d7347f5e2fae5f0af613741d06"},
+    {file = "numpy-2.0.1-cp39-cp39-macosx_14_0_x86_64.whl", hash = "sha256:ec87f5f8aca726117a1c9b7083e7656a9d0d606eec7299cc067bb83d26f16e0c"},
+    {file = "numpy-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f682ea61a88479d9498bf2091fdcd722b090724b08b31d63e022adc063bad59"},
+    {file = "numpy-2.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8efc84f01c1cd7e34b3fb310183e72fcdf55293ee736d679b6d35b35d80bba26"},
+    {file = "numpy-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:3fdabe3e2a52bc4eff8dc7a5044342f8bd9f11ef0934fcd3289a788c0eb10018"},
+    {file = "numpy-2.0.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:24a0e1befbfa14615b49ba9659d3d8818a0f4d8a1c5822af8696706fbda7310c"},
+    {file = "numpy-2.0.1-cp39-cp39-win32.whl", hash = "sha256:f9cf5ea551aec449206954b075db819f52adc1638d46a6738253a712d553c7b4"},
+    {file = "numpy-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:e9e81fa9017eaa416c056e5d9e71be93d05e2c3c2ab308d23307a8bc4443c368"},
+    {file = "numpy-2.0.1-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:61728fba1e464f789b11deb78a57805c70b2ed02343560456190d0501ba37b0f"},
+    {file = "numpy-2.0.1-pp39-pypy39_pp73-macosx_14_0_x86_64.whl", hash = "sha256:12f5d865d60fb9734e60a60f1d5afa6d962d8d4467c120a1c0cda6eb2964437d"},
+    {file = "numpy-2.0.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eacf3291e263d5a67d8c1a581a8ebbcfd6447204ef58828caf69a5e3e8c75990"},
+    {file = "numpy-2.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2c3a346ae20cfd80b6cfd3e60dc179963ef2ea58da5ec074fd3d9e7a1e7ba97f"},
+    {file = "numpy-2.0.1.tar.gz", hash = "sha256:485b87235796410c3519a699cfe1faab097e509e90ebb05dcd098db2ae87e7b3"},
+]
+
+[[package]]
 name = "packaging"
 version = "24.1"
 description = "Core utilities for Python packages"
@@ -188,13 +261,13 @@ type = ["mypy (>=1.8)"]
 
 [[package]]
 name = "pre-commit"
-version = "3.7.1"
+version = "3.8.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "pre_commit-3.7.1-py2.py3-none-any.whl", hash = "sha256:fae36fd1d7ad7d6a5a1c0b0d5adb2ed1a3bda5a21bf6c3e5372073d7a11cd4c5"},
-    {file = "pre_commit-3.7.1.tar.gz", hash = "sha256:8ca3ad567bc78a4972a3f1a477e94a79d4597e8140a6e0b651c5e33899c3654a"},
+    {file = "pre_commit-3.8.0-py2.py3-none-any.whl", hash = "sha256:9a90a53bf82fdd8778d58085faf8d83df56e40dfe18f45b19446e26bf1b3a63f"},
+    {file = "pre_commit-3.8.0.tar.gz", hash = "sha256:8bb6494d4a20423842e198980c9ecf9f96607a07ea29549e180eef9ae80fe7af"},
 ]
 
 [package.dependencies]
@@ -206,62 +279,62 @@ virtualenv = ">=20.10.0"
 
 [[package]]
 name = "pygame-ce"
-version = "2.4.1"
+version = "2.5.0"
 description = "Python Game Development"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pygame-ce-2.4.1.tar.gz", hash = "sha256:70a84aa1417c633a0fd6754ffa5dc92ee1b9aeb70baaa52c8c8c94a7c6db9cf0"},
-    {file = "pygame_ce-2.4.1-cp310-cp310-macosx_10_11_x86_64.whl", hash = "sha256:d1a932298657ea63fedba0c5fdff018ff5c7a92718df58102de23f0646f1720a"},
-    {file = "pygame_ce-2.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:560e502bb53678bd323011b486ac140a31579e2c792b1c61fcd0a375eb3bb579"},
-    {file = "pygame_ce-2.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba19c6f260e3df61fdc4782755c0adac62290ba029207c2a214730cb865e0a1f"},
-    {file = "pygame_ce-2.4.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e11cdef4c3c76d84f2c2fab61cc05ad118e2161768ddc8ff2db6b971e60af12"},
-    {file = "pygame_ce-2.4.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51dac117469b16cd97bcd74f5e16e085fa44c96346108ee8821843c02877818a"},
-    {file = "pygame_ce-2.4.1-cp310-cp310-win32.whl", hash = "sha256:3d7abf5f174ab5bce2a94914506c80ce979722b7002e23c1b51ef11d1aa30409"},
-    {file = "pygame_ce-2.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:5b7b2b2f75b833912b620b04a2f1e17cd3a45414d4b8ebd2cdb67c74bdd9b734"},
-    {file = "pygame_ce-2.4.1-cp311-cp311-macosx_10_11_x86_64.whl", hash = "sha256:9b48f93b2a7cbd4c7ffe949c39129f7ce07942a8de3371f6b56347361cf601b0"},
-    {file = "pygame_ce-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5b1b354de323b516af2660f14f2efe24ad3a818d859cfb99fbfcedda01518bcc"},
-    {file = "pygame_ce-2.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4404b63202fc6328fd80cc2ee335e0e22c36f012a33733ad61e1c41de15182d9"},
-    {file = "pygame_ce-2.4.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9cd31f46391262e0c31068e9957b8a6d569119eedb9a2452720dd4736735369f"},
-    {file = "pygame_ce-2.4.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2156c7c4a06a27c5372b72d63e9d32bbedf9dc0ce22d72f06eea00246c2d73b6"},
-    {file = "pygame_ce-2.4.1-cp311-cp311-win32.whl", hash = "sha256:d6f832b6b352e1fd6fc67074a00a2b082c18e6e6bc4190e827dabe9605fba5c1"},
-    {file = "pygame_ce-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:60f4ff63be4fa3b5a20f014988a5bb588be176acc774ca079c5494f500b53295"},
-    {file = "pygame_ce-2.4.1-cp312-cp312-macosx_10_11_x86_64.whl", hash = "sha256:a197952d4446b9cffcfc3c0b3ae396a36279925ad3ba920f85327e87c903608d"},
-    {file = "pygame_ce-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6fca3cf129daf8a75a1fac441756600addfd2f47fcfbb24cc744c6824cec9076"},
-    {file = "pygame_ce-2.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3495d07eb78f4a4e7dc46b0a6fc1d9fbbaaa0205cbcfaf19108409fbf837018b"},
-    {file = "pygame_ce-2.4.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bb34ecc0989e2852c14746828c6c696263b60e4bf67f18987dde9df3e1de09dc"},
-    {file = "pygame_ce-2.4.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1635743e0daa9a09992339b25f09c802c45e1ec93c8e600c5d3bd2639ad5d97"},
-    {file = "pygame_ce-2.4.1-cp312-cp312-win32.whl", hash = "sha256:50f315e3002373650d4ca4d8e4bdc34fdfd5d2c1b7e1bbf36a7dc78db68de7e5"},
-    {file = "pygame_ce-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:42a324f14e4f8485ec180cd7bc912caf48d580599c58d6caa1d83b5e5ed251c7"},
-    {file = "pygame_ce-2.4.1-cp38-cp38-macosx_10_11_x86_64.whl", hash = "sha256:e37db7e8555a845fdf2ad2bf91ef7ba3af363d79f7f7a706139fe340860319cc"},
-    {file = "pygame_ce-2.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6bb68112dcb5cadc82d8166d08cca7ebf6d512d59f0d30c972f302de4dfd2106"},
-    {file = "pygame_ce-2.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4086732bc167a515d76d54caf79b0cbee36dac7f01547f5743b5b677a82bd315"},
-    {file = "pygame_ce-2.4.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:51cba484d7a94e2ceb5360eef0157778ddcb34afbf8ffb7045e9f57edb8ad105"},
-    {file = "pygame_ce-2.4.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50fd863edd88a635e1098acd082e9e6c02c7fd40725cc4da1bfa67696ea8e126"},
-    {file = "pygame_ce-2.4.1-cp38-cp38-win32.whl", hash = "sha256:928a91744a30b24a8c553ae4809b76e738ff910e65866be42ab9c89909743077"},
-    {file = "pygame_ce-2.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0ead167d28712716bbac2a26b851b0e9657f5ab2edb163f3d24b1d32de46efe3"},
-    {file = "pygame_ce-2.4.1-cp39-cp39-macosx_10_11_x86_64.whl", hash = "sha256:b6b9aafa538b7102b290fd533caf84f869f747a187bf9e68010e12a40dedfb9e"},
-    {file = "pygame_ce-2.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:be5fea1b601f7f4834d53b3dc178e8a96a5c1dcfbcd13aba9e94681c98ab146e"},
-    {file = "pygame_ce-2.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7abef7fc4b49bced79a0e180e76e941b5507b9ff8901167d1fe6d6e18bf24f79"},
-    {file = "pygame_ce-2.4.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5c3d786b165975fa18b74e6addff70c3c3fed2df3c7d26c82337eb24a60920c0"},
-    {file = "pygame_ce-2.4.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54f4b4936fb204f7fe9effe1ced306da6d06ccd7482224ea75eb09c594a27e24"},
-    {file = "pygame_ce-2.4.1-cp39-cp39-win32.whl", hash = "sha256:2f69b98d203a44e3ba1fe0e8e71dcac3b230a345d59980e927639f58e68c97d6"},
-    {file = "pygame_ce-2.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:8bf8c85edb6f9dcd97737ddcb61eb5cee5541ef5007955c6c7417af0159a5a31"},
-    {file = "pygame_ce-2.4.1-pp310-pypy310_pp73-macosx_10_11_x86_64.whl", hash = "sha256:9695cd834b962faf654edcb81a7a69768b0409c341aa63cb5443da98fef69c68"},
-    {file = "pygame_ce-2.4.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6529ce436de8b420797ec05a963d6ecfd2be6b33c8d251b9abebfdef5bfa1a6f"},
-    {file = "pygame_ce-2.4.1-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2626966acea89c15bcd09f19589e104cda04692ff9dcccf3e97999e17f7b318f"},
-    {file = "pygame_ce-2.4.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:752103605b9b6485373c234488abb05f50929d915799784a62dd1782ae17e489"},
-    {file = "pygame_ce-2.4.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:a67cde0186b415fe2d5815f1d2d4afd7bed261465eaba00f075e5f549b975761"},
-    {file = "pygame_ce-2.4.1-pp38-pypy38_pp73-macosx_10_11_x86_64.whl", hash = "sha256:9d304812feaad6345ddcf0c86f448a97e6dc6337e45b7d55b1a3308f55d728e7"},
-    {file = "pygame_ce-2.4.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7e8acddf0c42163ec6fa3e24d65c179ca840bc304b826882ec17849ced49e649"},
-    {file = "pygame_ce-2.4.1-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:28d5d812344e9151d05b4cf2714cc04d6fcb28cf8fe4c682c207c7483634a428"},
-    {file = "pygame_ce-2.4.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c5402524398219a88c73eab0584e880e8c1e029ecbdb4e94bc2bde566b6ec69e"},
-    {file = "pygame_ce-2.4.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:3897ae41dd59a59c4d690c81c53c076a3ea022176684d1869fb46ba98b06ebb2"},
-    {file = "pygame_ce-2.4.1-pp39-pypy39_pp73-macosx_10_11_x86_64.whl", hash = "sha256:2beedd02a1a6b25bf7a145def1164e160001ef34556edfec9968bbcb8ad05cc3"},
-    {file = "pygame_ce-2.4.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32c7d1bc60d9375188f6586b0e30a66db07443739f1c119e7cc2bc7c8ad898f4"},
-    {file = "pygame_ce-2.4.1-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1598a8e43e39b775066265696bf8e7e55b3e5205670f167295702ee661547db2"},
-    {file = "pygame_ce-2.4.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:875c359b278b44905e7bde3bd9507ed0aa66e85efc7fce4df3e671b20af079b3"},
-    {file = "pygame_ce-2.4.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:e67e3a749c581d198f3e512d8750671749e233cd8712d386086de04cebf556e3"},
+    {file = "pygame_ce-2.5.0-cp310-cp310-macosx_10_11_x86_64.whl", hash = "sha256:408fcfef84a93844c077b1cb7323886548426b2f074845998b43d2029440cd12"},
+    {file = "pygame_ce-2.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7c45632bec67f6fffb2caa5b09511c2796b42c54680477e36253e9b4b3dee7ff"},
+    {file = "pygame_ce-2.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2bf7f4435c66b7f0f8a125c5e4c47a649b627954326f1258de7f2c9bf7e6c0b"},
+    {file = "pygame_ce-2.5.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:10a61373f1a98e483dee70b21a96f378167ae1a718a3995fce7acc7699059574"},
+    {file = "pygame_ce-2.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce200bec2d40eb15e29a948d7baa894c771fc77261f1a6511e90e99684f27148"},
+    {file = "pygame_ce-2.5.0-cp310-cp310-win32.whl", hash = "sha256:9a3c8febec59a26e1be91250e6a040f10265f80f56132960329882df60a8f89b"},
+    {file = "pygame_ce-2.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:4a0b67a416190c3b774e9b740cf23a21ba27d2d679994378aa6c4bfa33317f69"},
+    {file = "pygame_ce-2.5.0-cp311-cp311-macosx_10_11_x86_64.whl", hash = "sha256:2d6c7d931ed1fd68b5da213663bb8002ea688d5899f026dc4b73be9097c4e2a9"},
+    {file = "pygame_ce-2.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e23dd76207308c4ecaa58cc417670924ba8327f325d61ca96aecc6915ebead22"},
+    {file = "pygame_ce-2.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a7f8f251b53d0b0dc68095571f222478531093ac1aec0b96bcfe8551c32bc76d"},
+    {file = "pygame_ce-2.5.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b67975e22f2f0670de5b3570e08b2518d9daf7ed19af51441907ac9804d3e5a"},
+    {file = "pygame_ce-2.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ac59c88d520a0d5a57cf82b952b1b62839bc869757744d1c972ed036c05aad1"},
+    {file = "pygame_ce-2.5.0-cp311-cp311-win32.whl", hash = "sha256:09cc46ffb45a2db64f8ee593bee09f883a57fa15936828d2c1d367853ed44bfa"},
+    {file = "pygame_ce-2.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d78324f2372d22bdb81485b1415b8a6e5c98d69bb65b3ee1bfb2a30f3e5f715"},
+    {file = "pygame_ce-2.5.0-cp312-cp312-macosx_10_11_x86_64.whl", hash = "sha256:f20a4f82252e27d31dc111da807803d227f5b16877d904bf511a1cad7ec41596"},
+    {file = "pygame_ce-2.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:72f5abd7045d9158c9728ab84449c0eedaebecc56b3fa28b271f77f70c3127bb"},
+    {file = "pygame_ce-2.5.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abef08bdf347b5ec33b98bb162c435749047e790db736594d6f4c85464cd7d35"},
+    {file = "pygame_ce-2.5.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:18f20596a118403bb9fd7c065aa5c1d846ff6248f2e49b3605ca08a09f73d7a6"},
+    {file = "pygame_ce-2.5.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87ea2512b573e0706c0e3181d9a16dc9f8c71df8cf5dde31b7430f585cd39385"},
+    {file = "pygame_ce-2.5.0-cp312-cp312-win32.whl", hash = "sha256:53a23cd31fa38b9908687c84b9d845669735476a10799323dc8adf050fc0b7c6"},
+    {file = "pygame_ce-2.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:2b290ca88e70c14b6a5184c54348334167bba35d2eb00c1c9a7e5179bcbaee40"},
+    {file = "pygame_ce-2.5.0-cp38-cp38-macosx_10_11_x86_64.whl", hash = "sha256:ca6c3f72ecfc196d87bb53f186bfbd8bc45274aa6bb1265ad419cb2f5501c9df"},
+    {file = "pygame_ce-2.5.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:731dd171e7a54d13f6cb652862a37f32f141e39b18f2ba1e011f5166bd382059"},
+    {file = "pygame_ce-2.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2647de29bc5bcd054504e0883663c91b2ffe8a7a10c7c0bce9968d3c06e75959"},
+    {file = "pygame_ce-2.5.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:48c59cd987870452b4bf26f8061147a509f0c97ee2f1d9f943c40c8f18102340"},
+    {file = "pygame_ce-2.5.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70c90304aa37290d2fc10919871cf1d6ec894c016ef979c1ee3d1e868bda17b0"},
+    {file = "pygame_ce-2.5.0-cp38-cp38-win32.whl", hash = "sha256:ef5fbe3f670d4efd6223d863bcd5cfa867167d86ca4c551b11754f748b7367b0"},
+    {file = "pygame_ce-2.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:f17aa8d52cfd0bc1f02b7a06c8020bedd2e4de9894ffddfd5642605ce7f92d9a"},
+    {file = "pygame_ce-2.5.0-cp39-cp39-macosx_10_11_x86_64.whl", hash = "sha256:204d4b13f9ade51c175bacca7c88e0b0b525a8d9a3798c4d7a3b80553b21321f"},
+    {file = "pygame_ce-2.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:eefb3d308e87d9f9bcd568780dff7f3ef96029ad2bba5efae3dc2d147d6aca6e"},
+    {file = "pygame_ce-2.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba7cf80909a7c81eccc3ec8af65041be8f97f441ca3d4ac185cbe2d04cb557eb"},
+    {file = "pygame_ce-2.5.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:088a4201e16b43409f45b99c5c14bcb84810d09bb46d32a5b9f28eb674f65e03"},
+    {file = "pygame_ce-2.5.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6737a74be09ab94348f46dae3c6c97493e5928ff6d9e8ac58ce5cc7e5542738"},
+    {file = "pygame_ce-2.5.0-cp39-cp39-win32.whl", hash = "sha256:ff2921a685ab0d5c1884b8a931963393b656d98ef9aad4274b5a1c7ad96c8994"},
+    {file = "pygame_ce-2.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:6ccc2deb07f457385595d2e77eee2ac6416e5b0e426a18f1d1bbd1600062d4f7"},
+    {file = "pygame_ce-2.5.0-pp310-pypy310_pp73-macosx_10_11_x86_64.whl", hash = "sha256:38601022b200d87cd918e0d6d8c99b4e86a1e92e727c325dcaf8a59ad1c667a6"},
+    {file = "pygame_ce-2.5.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:541df74359a42c254536d48e00b039e7c4ffad54c66b0471bb9f3480133c8b08"},
+    {file = "pygame_ce-2.5.0-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:94c5e63b49b94d52ed8b60cd888fd119d2825a801356328b310e345854650fec"},
+    {file = "pygame_ce-2.5.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:df482729ddd6fc45e8329e68d4bb05eb93c06d6527b15f5b2e14146c249b3025"},
+    {file = "pygame_ce-2.5.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:eb8f4d3cc70c0ece2105017ffe710468a1cc70f0fbe63d71782f94a929097e88"},
+    {file = "pygame_ce-2.5.0-pp38-pypy38_pp73-macosx_10_11_x86_64.whl", hash = "sha256:feb4cb900c7e788cffd1d1c8a9db7097809d974440cdd47871217a489f628604"},
+    {file = "pygame_ce-2.5.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8226dab63413dad487cd748cf959aa8c9dfdec9e12122347c2fb14493c7e697a"},
+    {file = "pygame_ce-2.5.0-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:03503aa4059168a1c4d0c42b95b289496834ef3234d06d1a6e842ed34c32b797"},
+    {file = "pygame_ce-2.5.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c4063cb05e924771a90231561826790225a09d7de3f5ed9bef7de8460e9f5b48"},
+    {file = "pygame_ce-2.5.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:98f271736e7a7b327bc88ce7e80129d7ea25869660224596a18220ae4e9e7e58"},
+    {file = "pygame_ce-2.5.0-pp39-pypy39_pp73-macosx_10_11_x86_64.whl", hash = "sha256:eda9631ba4fa8a46f5c358abfc32473c50ed96408fa9031fdac98e2290a3e56f"},
+    {file = "pygame_ce-2.5.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f980f44f13eb178f719599f87f2f3b13afd0ef3ac796761797d16f45c68a15b8"},
+    {file = "pygame_ce-2.5.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2937ca1d80b40520621c3100c7a4dc47cc912c7f93450fc3dcb92be5e28135c5"},
+    {file = "pygame_ce-2.5.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ef61b7d38b2764f457aaf7b0dcd5b38b2c896c7fb7dc9183254ee128fb280ef"},
+    {file = "pygame_ce-2.5.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:60ce604fc29891746ecbe53aa5b1130e329b56e27aa8a6df8ef31fa6515f53e6"},
+    {file = "pygame_ce-2.5.0.tar.gz", hash = "sha256:76d47c6b49237ffff7656e4bebc4032a89f6025b70bfad7cb0fb4be2bfdcbe77"},
 ]
 
 [[package]]
@@ -340,62 +413,64 @@ files = [
 
 [[package]]
 name = "pyyaml"
-version = "6.0.1"
+version = "6.0.2"
 description = "YAML parser and emitter for Python"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 files = [
-    {file = "PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a"},
-    {file = "PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"},
-    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
-    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
-    {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
-    {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
-    {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
-    {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
-    {file = "PyYAML-6.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab"},
-    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
-    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
-    {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
-    {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
-    {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
-    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afd7e57eddb1a54f0f1a974bc4391af8bcce0b444685d936840f125cf046d5bd"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-win32.whl", hash = "sha256:fca0e3a251908a499833aa292323f32437106001d436eca0e6e7833256674585"},
-    {file = "PyYAML-6.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:f22ac1c3cac4dbc50079e965eba2c1058622631e526bd9afd45fedd49ba781fa"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b1275ad35a5d18c62a7220633c913e1b42d44b46ee12554e5fd39c70a243d6a3"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18aeb1bf9a78867dc38b259769503436b7c72f7a1f1f4c93ff9a17de54319b27"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:596106435fa6ad000c2991a98fa58eeb8656ef2325d7e158344fb33864ed87e3"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:baa90d3f661d43131ca170712d903e6295d1f7a0f595074f151c0aed377c9b9c"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-win32.whl", hash = "sha256:9046c58c4395dff28dd494285c82ba00b546adfc7ef001486fbf0324bc174fba"},
-    {file = "PyYAML-6.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:4fb147e7a67ef577a588a0e2c17b6db51dda102c71de36f8549b6816a96e1867"},
-    {file = "PyYAML-6.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1d4c7e777c441b20e32f52bd377e0c409713e8bb1386e1099c2415f26e479595"},
-    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
-    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
-    {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
-    {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
-    {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
-    {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
-    {file = "PyYAML-6.0.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c8098ddcc2a85b61647b2590f825f3db38891662cfc2fc776415143f599bb859"},
-    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
-    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
-    {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
-    {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
-    {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086"},
+    {file = "PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b"},
+    {file = "PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180"},
+    {file = "PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99"},
+    {file = "PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774"},
+    {file = "PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317"},
+    {file = "PyYAML-6.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"},
+    {file = "PyYAML-6.0.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win32.whl", hash = "sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5"},
+    {file = "PyYAML-6.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab"},
+    {file = "PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425"},
+    {file = "PyYAML-6.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48"},
+    {file = "PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4"},
+    {file = "PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba"},
+    {file = "PyYAML-6.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484"},
+    {file = "PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc"},
+    {file = "PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183"},
+    {file = "PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563"},
+    {file = "PyYAML-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d"},
+    {file = "PyYAML-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083"},
+    {file = "PyYAML-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win32.whl", hash = "sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a"},
+    {file = "PyYAML-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d"},
+    {file = "PyYAML-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12"},
+    {file = "PyYAML-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e"},
+    {file = "PyYAML-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win32.whl", hash = "sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631"},
+    {file = "PyYAML-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8"},
+    {file = "pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"},
 ]
 
 [[package]]
@@ -418,18 +493,19 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "setuptools"
-version = "70.3.0"
+version = "72.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-70.3.0-py3-none-any.whl", hash = "sha256:fe384da74336c398e0d956d1cae0669bc02eed936cdb1d49b57de1990dc11ffc"},
-    {file = "setuptools-70.3.0.tar.gz", hash = "sha256:f171bab1dfbc86b132997f26a119f6056a57950d058587841a0082e8830f9dc5"},
+    {file = "setuptools-72.1.0-py3-none-any.whl", hash = "sha256:5a03e1860cf56bb6ef48ce186b0e557fdba433237481a9a625176c2831be15d1"},
+    {file = "setuptools-72.1.0.tar.gz", hash = "sha256:8d243eff56d095e5817f796ede6ae32941278f542e0f941867cc05ae52b162ec"},
 ]
 
 [package.extras]
+core = ["importlib-metadata (>=6)", "importlib-resources (>=5.10.2)", "jaraco.text (>=3.7)", "more-itertools (>=8.8)", "ordered-set (>=3.1.1)", "packaging (>=24)", "platformdirs (>=2.6.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "mypy (==1.10.0)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.3.2)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "mypy (==1.11.*)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (<0.4)", "pytest-ruff (>=0.2.1)", "pytest-ruff (>=0.3.2)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "shellingham"
@@ -493,4 +569,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12,<3.13"
-content-hash = "059a5e2635c7df8fb7cea81e53d0808d9a6bae46b4bcb63acbfed232f1b1d108"
+content-hash = "ef712ea0aa28663954b267c2e5090e5678778b36a4405aee374c8e9b91a17b9a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,10 @@ pucoti = "pucoti:app"
 
 [tool.poetry.dependencies]
 python = "^3.12,<3.13"
-pygame-ce = "2.4.1"
-typer = "^0.12.3"
+pygame-ce = "2.5.0"
+typer = "0.12.3"
 pyyaml = "^6.0.1"
+luckypot = {git = "https://github.com/ddorn/luckypot.git"}
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.7.1"

--- a/src/app.py
+++ b/src/app.py
@@ -18,96 +18,103 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-
-import json
 import os
 from pprint import pprint
-import sys
-from time import time
-import re
 import typer
-from typer import Option
-from enum import Enum
-import atexit
+
 
 # By default pygame prints its version to the console when imported. We deactivate that.
 os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "hide"
 
 import pygame
 import pygame.locals as pg
-import pygame._sdl2 as sdl2
+import luckypot
 
 
-from src import pygame_utils
-from src import time_utils
 from src import constants
-from src import platforms
-from src.purpose import Purpose
-from src.callback import CountdownCallback
 from src.config import PucotiConfig
+from src.screens.base_screen import PucotiScreen, Context
+from src.screens.start_screen import StartScreen
+from src import platforms
+from src import pygame_utils
 
 
-class Scene(Enum):
-    MAIN = "main"
-    HELP = "help"
-    PURPOSE_HISTORY = "purpose_history"
-    ENTERING_PURPOSE = "entering_purpose"
+class App(luckypot.App[PucotiScreen]):
+    NAME = "PUCOTI"
+    INITIAL_STATE = StartScreen
 
-    def mk_layout(
-        self, screen_size: tuple[float, float], has_purpose: bool, no_total: bool = False
-    ) -> dict[str, pygame.Rect]:
-        width, height = screen_size
-        screen = pygame.Rect((0, 0), screen_size)
+    def __init__(self, config: PucotiConfig):
+        self.config = config
+        self.ctx = Context(
+            config=config,
+            app=self,
+        )
+        self.INITIAL_SIZE = config.window.initial_size
+        self.WINDOW_KWARGS["borderless"] = config.window.borderless
+        self.WINDOW_KWARGS["resizable"] = True
+        self.WINDOW_KWARGS["always_on_top"] = True
 
-        if width > 200:
-            screen = screen.inflate(-width // 10, 0)
+        super().__init__()
+        pygame.key.set_repeat(300, 20)
+        platforms.place_window(self.window, *config.window.initial_position)
 
-        if self == Scene.HELP:
-            layout = {"help": 1}
-        elif self == Scene.PURPOSE_HISTORY:
-            layout = {"purpose_history": 1}
-        elif self == Scene.ENTERING_PURPOSE:
-            if height < 60:
-                layout = {"purpose": 1}
-            elif height < 80:
-                layout = {"purpose": 2, "time": 1}
+        self.window_has_focus = True
+
+        self.position_index = 0
+        self.window_positions = list(constants.POSITIONS)
+        if config.window.initial_position not in self.window_positions:
+            self.window_positions.insert(0, config.window.initial_position)
+
+    @property
+    def current_window_position(self):
+        return self.window_positions[self.position_index % len(self.window_positions)]
+
+    def handle_event(self, event) -> bool:
+        # We want the state to handle the event first.
+        if super().handle_event(event):
+            return True
+
+        if event.type == pg.KEYDOWN:
+            if event.key == pg.K_p:
+                self.position_index += 1
+                platforms.place_window(
+                    self.ctx.app.window,
+                    *self.current_window_position,
+                )
+            elif event.key == pg.K_MINUS:
+                pygame_utils.scale_window(
+                    self.window, 1 / constants.WINDOW_SCALE, constants.MIN_WINDOW_SIZE
+                )
+                platforms.place_window(self.window, *self.current_window_position)
+            elif event.key in (pg.K_PLUS, pg.K_EQUALS):
+                pygame_utils.scale_window(
+                    self.window, constants.WINDOW_SCALE, constants.MIN_WINDOW_SIZE
+                )
+                platforms.place_window(self.window, *self.current_window_position)
             else:
-                layout = {"purpose": 2, "time": 1, "totals": 0.5}
-        elif self == Scene.MAIN:
-            if height < 60:
-                layout = {"time": 1}
-            elif height < 80:
-                layout = {"purpose": 1, "time": 2}
-            else:
-                layout = {"purpose": 1, "time": 2, "totals": 1}
+                return False
+            return True
 
-            if not has_purpose:
-                layout["time"] += layout.pop("purpose", 0)
-        else:
-            raise ValueError(f"Invalid scene: {self}")
+        elif event.type == pg.WINDOWFOCUSGAINED:
+            self.window_has_focus = True
+        elif event.type == pg.WINDOWFOCUSLOST:
+            self.window_has_focus = False
+        return False
 
-        if no_total:
-            layout.pop("totals", None)
+    def draw(self):
+        super().draw()
 
-        rects = {
-            k: rect
-            for k, rect in zip(layout.keys(), pygame_utils.split_rect(screen, *layout.values()))
-        }
+        # Show border if focused
+        if self.window_has_focus:
+            screen = self.gfx.surf
+            pygame.draw.rect(screen, self.config.color.purpose, screen.get_rect(), 1)
 
-        # Bottom has horizontal layout with [total_time | purpose_time]
-        if total_time_rect := rects.pop("totals", None):
-            rects["total_time"], _, rects["purpose_time"] = pygame_utils.split_rect(
-                total_time_rect, 1, 0.2, 1, horizontal=True
-            )
-
-        return rects
+    def on_state_enter(self, state):
+        super().on_state_enter(state)
+        state.ctx = self.ctx
 
 
 app = typer.Typer(add_completion=False)
-
-
-def StyleOpt(help=None, **kwargs):
-    return Option(help=help, rich_help_panel="Style", **kwargs)
 
 
 @app.command(
@@ -118,255 +125,7 @@ def StyleOpt(help=None, **kwargs):
 def main(config: PucotiConfig) -> None:
     pprint(config)
 
-    history_file = config.history_file.expanduser()
-    history_file.parent.mkdir(parents=True, exist_ok=True)
-    history_file.touch(exist_ok=True)
-
-    pygame.init()
-    pygame.mixer.init()
-    pygame.key.set_repeat(300, 20)
-
-    window = sdl2.Window(
-        "PUCOTI", config.window.initial_size, borderless=True, always_on_top=True, resizable=True
-    )
-    window.get_surface().fill((0, 0, 0))
-    window.flip()
-    window_has_focus = True
-
-    screen = window.get_surface()
-    clock = pygame.time.Clock()
-
-    position = 0
-    platforms.place_window(window, *config.window.initial_position)
-
-    initial_duration = time_utils.human_duration(config.initial_timer)
-    start = round(time())
-    timer_end = initial_duration
-    last_rung = 0
-    nb_rings = 0
-    callbacks = [CountdownCallback(cfg) for cfg in config.run_at]
-
-    purpose_history = [
-        Purpose(**json.loads(line))
-        for line in history_file.read_text().splitlines()
-        if line.strip()
-    ]
-    purpose = ""
-    purpose_start_time = int(time())
-    history_lines = 10
-    history_scroll = 0  # From the bottom
-    show_relative_time = True
-    hide_total = False
-
-    last_scene = None
-    scene = Scene.MAIN
-
-    # Hook to save the last purpose end time when the program is closed.
-    @atexit.register
-    def save_last_purpose():
-        if purpose:
-            Purpose("").add_to_history(history_file)
-
-    while True:
-        last_scene = scene
-        for event in pygame.event.get():
-            if event.type == pg.QUIT:
-                sys.exit()
-            elif event.type == pg.WINDOWFOCUSGAINED:
-                window_has_focus = True
-            elif event.type == pg.WINDOWFOCUSLOST:
-                window_has_focus = False
-            elif event.type == pg.TEXTINPUT and scene == Scene.ENTERING_PURPOSE:
-                purpose += event.text
-            elif event.type == pg.KEYDOWN:
-                if scene == Scene.HELP:
-                    scene = Scene.MAIN
-                elif scene == Scene.ENTERING_PURPOSE:
-                    if event.key == pg.K_BACKSPACE:
-                        if event.mod & pg.KMOD_CTRL:
-                            purpose = re.sub(r"\S*\s*$", "", purpose)
-                        else:
-                            purpose = purpose[:-1]
-                    elif event.key in (pg.K_RETURN, pg.K_KP_ENTER, pg.K_ESCAPE):
-                        scene = Scene.MAIN
-
-                elif scene == Scene.PURPOSE_HISTORY:
-                    if event.key == pg.K_j:
-                        history_scroll = max(0, history_scroll - 1)
-                    elif event.key == pg.K_k:
-                        history_scroll = min(
-                            len([p for p in purpose_history if p.text]) - history_lines,
-                            history_scroll + 1,
-                        )
-                    elif event.key == pg.K_l:
-                        show_relative_time = not show_relative_time
-                    else:
-                        scene = Scene.MAIN
-                elif event.key == pg.K_j:
-                    timer_end -= 60 * 5 if pygame_utils.shift_is_pressed(event) else 60
-                elif event.key == pg.K_k:
-                    timer_end += 60 * 5 if pygame_utils.shift_is_pressed(event) else 60
-                elif event.key in constants.NUMBER_KEYS:
-                    new_duration = 60 * pygame_utils.get_number_from_key(event.key)
-                    if pygame_utils.shift_is_pressed(event):
-                        new_duration *= 10
-                    timer_end = time_utils.compute_timer_end(new_duration, start)
-                    initial_duration = new_duration
-                elif event.key == pg.K_r:
-                    timer_end = time_utils.compute_timer_end(initial_duration, start)
-                elif event.key == pg.K_MINUS:
-                    pygame_utils.scale_window(
-                        window, 1 / constants.WINDOW_SCALE, constants.MIN_WINDOW_SIZE
-                    )
-                    platforms.place_window(window, *constants.POSITIONS[position])
-                elif event.key == pg.K_PLUS or event.key == pg.K_EQUALS:
-                    pygame_utils.scale_window(
-                        window, constants.WINDOW_SCALE, constants.MIN_WINDOW_SIZE
-                    )
-                    platforms.place_window(window, *constants.POSITIONS[position])
-                elif event.key == pg.K_p:
-                    position = (position + 1) % len(constants.POSITIONS)
-                    platforms.place_window(window, *constants.POSITIONS[position])
-                elif event.key == pg.K_t:
-                    hide_total = not hide_total
-                elif event.key in (pg.K_RETURN, pg.K_KP_ENTER):
-                    scene = Scene.ENTERING_PURPOSE
-                elif event.key in (pg.K_h, pg.K_QUESTION):
-                    scene = Scene.HELP
-                elif event.key == pg.K_l:
-                    scene = Scene.PURPOSE_HISTORY
-
-        if last_scene == Scene.ENTERING_PURPOSE and scene != last_scene:
-            if not purpose_history or purpose != purpose_history[-1].text:
-                purpose_start_time = round(time())
-                purpose_history.append(Purpose(purpose))
-                purpose_history[-1].add_to_history(history_file)
-
-        layout = scene.mk_layout(window.size, bool(purpose), hide_total)
-
-        screen.fill(config.color.background)
-
-        # Render purpose, if there is space.
-        if purpose_rect := layout.get("purpose"):
-            t = config.font.normal.render(purpose, purpose_rect.size, config.color.purpose)
-            r = screen.blit(t, t.get_rect(center=purpose_rect.center))
-            if scene == Scene.ENTERING_PURPOSE and (time() % 1) < 0.7:
-                if r.height == 0:
-                    r.height = purpose_rect.height
-                if r.right >= purpose_rect.right:
-                    r.right = purpose_rect.right - 3
-                pygame.draw.line(screen, config.color.purpose, r.topright, r.bottomright, 2)
-
-        # Render time.
-        remaining = timer_end - (time() - start)
-        if time_rect := layout.get("time"):
-            color = config.color.timer_up if remaining < 0 else config.color.timer
-            t = config.font.big.render(
-                time_utils.fmt_duration(abs(remaining)),
-                time_rect.size,
-                color,
-                monospaced_time=True,
-            )
-            screen.blit(t, t.get_rect(center=time_rect.center))
-
-        if total_time_rect := layout.get("total_time"):
-            t = config.font.normal.render(
-                time_utils.fmt_duration(time() - start),
-                total_time_rect.size,
-                config.color.total_time,
-                monospaced_time=True,
-            )
-            screen.blit(t, t.get_rect(midleft=total_time_rect.midleft))
-
-        if purpose_time_rect := layout.get("purpose_time"):
-            t = config.font.normal.render(
-                time_utils.fmt_duration(time() - purpose_start_time),
-                purpose_time_rect.size,
-                config.color.purpose,
-                monospaced_time=True,
-            )
-            screen.blit(t, t.get_rect(midright=purpose_time_rect.midright))
-
-        if help_rect := layout.get("help"):
-            title = "PUCOTI Bindings"
-            s = config.font.normal.table(
-                [line.split(": ") for line in constants.SHORTCUTS.split("\n")],  # type: ignore
-                help_rect.size,
-                [config.color.purpose, config.color.timer],
-                title=title,
-                col_sep=": ",
-                align=[pg.FONT_RIGHT, pg.FONT_LEFT],
-                title_color=config.color.timer,
-            )
-            screen.blit(s, s.get_rect(center=help_rect.center))
-
-        if purpose_history_rect := layout.get("purpose_history"):
-            timestamps = [p.timestamp for p in purpose_history] + [time()]
-            rows = [
-                [
-                    time_utils.fmt_duration(end_time - p.timestamp),
-                    pygame_utils.shorten(p.text, 40),
-                    time_utils.fmt_time(p.timestamp, relative=show_relative_time),
-                ]
-                for p, end_time in zip(purpose_history, timestamps[1:], strict=True)
-                if p.text
-            ]
-            first_shown = len(rows) - history_lines - history_scroll
-            last_shown = len(rows) - history_scroll
-            hidden_rows = rows[:first_shown] + rows[last_shown:]
-            rows = rows[first_shown:last_shown]
-
-            headers = ["Span", "Purpose [J/K]", "Started [L]"]
-            s = config.font.normal.table(
-                [headers] + rows,
-                purpose_history_rect.size,
-                [config.color.total_time, config.color.purpose, config.color.timer],
-                title="History",
-                col_sep=": ",
-                align=[pg.FONT_RIGHT, pg.FONT_LEFT, pg.FONT_RIGHT],
-                title_color=config.color.purpose,
-                hidden_rows=hidden_rows,
-                header_line_color=config.color.purpose,
-            )
-            screen.blit(s, s.get_rect(center=purpose_history_rect.center))
-
-        # Show border if focused
-        if window_has_focus:
-            pygame.draw.rect(screen, config.color.purpose, screen.get_rect(), 1)
-
-        # If \ is pressed, show the rects in locals()
-        if pygame.key.get_pressed()[pg.K_BACKSLASH]:
-            debug_font = config.font.normal.get_font(20)
-            for name, rect in locals().items():
-                if isinstance(rect, pygame.Rect):
-                    color = pygame_utils.random_color(name)
-                    pygame.draw.rect(screen, color, rect, 1)
-                    # and its name
-                    t = debug_font.render(name, True, (255, 255, 255))
-                    screen.blit(t, rect.topleft)
-
-        # Ring the bell if the time is up.
-        if (
-            remaining < 0
-            and time() - last_rung > config.ring_every
-            and nb_rings != config.ring_count
-        ):
-            last_rung = time()
-            nb_rings += 1
-            pygame_utils.play(config.bell)
-            if config.restart:
-                timer_end = initial_duration + (round(time() + 0.5) - start)
-
-        elif remaining > 0:
-            nb_rings = 0
-            last_rung = 0
-
-        # And execute the callbacks.
-        for callback in callbacks:
-            callback.update(timer_end - (time() - start))
-
-        window.flip()
-        clock.tick(30)
+    App(config).run()
 
 
 if __name__ == "__main__":

--- a/src/base_config.py
+++ b/src/base_config.py
@@ -300,6 +300,7 @@ class Config:
                 try:
                     config = cls().load(constants.CONFIG_FILE)
                 except FileNotFoundError:
+                    print(f"Config file not found at {constants.CONFIG_FILE}")
                     config = cls()
 
                 params_overwritten_by_cli = {

--- a/src/callback.py
+++ b/src/callback.py
@@ -4,7 +4,6 @@ from src import time_utils
 from src.config import RunAtConfig
 
 
-
 class CountdownCallback:
     """Call a command once the timer goes below a specific time."""
 

--- a/src/config.py
+++ b/src/config.py
@@ -51,6 +51,7 @@ class ColorConfig(Config):
 class WindowConfig(Config):
     initial_position: tuple[int, int] = (-5, -5)
     initial_size: tuple[int, int] = (220, 80)
+    borderless: bool = True
 
 
 @dataclass(frozen=True)

--- a/src/purpose.py
+++ b/src/purpose.py
@@ -11,5 +11,5 @@ class Purpose:
     timestamp: float = dataclasses.field(default_factory=time)
 
     def add_to_history(self, history_file: Path):
-        with history_file.open("a") as f:
+        with history_file.expanduser().open("a") as f:
             f.write(json.dumps(self.__dict__) + "\n")

--- a/src/screens/base_screen.py
+++ b/src/screens/base_screen.py
@@ -1,0 +1,61 @@
+from dataclasses import dataclass
+import json
+from pathlib import Path
+
+import pygame.locals as pg
+import luckypot
+
+from ..purpose import Purpose
+from ..config import PucotiConfig
+
+
+@dataclass
+class Context:
+    config: PucotiConfig
+    app: luckypot.App
+    history_file: Path
+    purpose_history: list[Purpose]
+
+    def __init__(self, config: PucotiConfig, app: luckypot.App):
+        self.config = config
+        self.app = app
+
+        self.history_file = config.history_file.expanduser()
+        self.history_file.parent.mkdir(parents=True, exist_ok=True)
+        self.history_file.touch(exist_ok=True)
+
+        self.purpose_history = [
+            Purpose(**json.loads(line))
+            for line in self.history_file.read_text().splitlines()
+            if line.strip()
+        ]
+
+    def set_purpose(self, purpose: str):
+        if not self.purpose_history or purpose != self.purpose_history[-1].text:
+            self.purpose_history.append(Purpose(purpose))
+            self.purpose_history[-1].add_to_history(self.config.history_file)
+
+
+class PucotiScreen(luckypot.AppState):
+    FPS = 30
+    ctx: Context  # Set once the state has been pushed to the stack.
+
+    @property
+    def config(self):
+        return self.ctx.config
+
+    def draw(self, gfx: luckypot.GFX):
+        super().draw(gfx)
+        gfx.fill(self.config.color.background)
+
+    def logic(self):
+        return super().logic()
+
+    def available_rect(self):
+        width, height = self.ctx.app.window.size
+        screen = pg.Rect(0, 0, width, height)
+
+        if width > 200:
+            screen = screen.inflate(-width // 10, 0)
+
+        return screen

--- a/src/screens/help_screen.py
+++ b/src/screens/help_screen.py
@@ -1,0 +1,34 @@
+from luckypot.gfx import GFX
+import pygame as pg
+
+from .. import constants
+from .base_screen import PucotiScreen
+
+
+class HelpScreen(PucotiScreen):
+
+    def handle_event(self, event) -> bool:
+        if super().handle_event(event):
+            return True
+
+        if event.type == pg.KEYDOWN:
+            self.pop_state()
+            return True
+
+        return False
+
+    def draw(self, gfx: GFX):
+        super().draw(gfx)
+        rect = self.available_rect()
+
+        title = "PUCOTI Bindings"
+        s = self.config.font.normal.table(
+            [line.split(": ") for line in constants.SHORTCUTS.split("\n")],  # type: ignore
+            rect.size,
+            [self.config.color.purpose, self.config.color.timer],
+            title=title,
+            col_sep=": ",
+            align=[pg.FONT_RIGHT, pg.FONT_LEFT],
+            title_color=self.config.color.timer,
+        )
+        gfx.blit(s, center=rect.center)

--- a/src/screens/main_screen.py
+++ b/src/screens/main_screen.py
@@ -1,0 +1,220 @@
+import re
+from time import time
+
+import pygame
+import pygame.locals as pg
+from luckypot import GFX
+
+from .. import time_utils
+from .. import pygame_utils
+from .. import constants
+from ..callback import CountdownCallback
+from .base_screen import PucotiScreen, Context
+from . import help_screen, purpose_history_screen
+
+
+class MainScreen(PucotiScreen):
+    def __init__(self, ctx: Context) -> None:
+        super().__init__()
+
+        self.initial_duration = time_utils.human_duration(ctx.config.initial_timer)
+        self.start = round(time())
+        self.timer_end = self.initial_duration
+        self.last_rung = 0
+        self.nb_rings = 0
+        self.callbacks = [CountdownCallback(cfg) for cfg in ctx.config.run_at]
+
+        self.hide_totals = False
+
+        self.purpose_editor = PurposeEditor(ctx)
+
+        ctx.set_purpose("")
+
+    @property
+    def purpose(self):
+        return self.ctx.purpose_history[-1].text
+
+    @property
+    def purpose_start_time(self):
+        return round(self.ctx.purpose_history[-1].timestamp)
+
+    def on_exit(self):
+        self.ctx.set_purpose("")
+
+    def paused_logic(self):
+        remaining = self.timer_end - (time() - self.start)
+        if (
+            remaining < 0
+            and time() - self.last_rung > self.config.ring_every
+            and self.nb_rings != self.config.ring_count
+        ):
+            self.last_rung = time()
+            self.nb_rings += 1
+            pygame_utils.play(self.config.bell)
+            if self.config.restart:
+                # self.timer_end = self.initial_duration + (round(time() + 0.5) - self.start)
+                self.timer_end = time_utils.compute_timer_end(self.initial_duration, self.start)
+
+        elif remaining > 0:
+            self.nb_rings = 0
+            self.last_rung = 0
+
+        # And execute the callbacks.
+        for callback in self.callbacks:
+            callback.update(self.timer_end - (time() - self.start))
+
+        return super().paused_logic()
+
+    def logic(self):
+        self.paused_logic()
+        return super().logic()
+
+    def handle_event(self, event) -> bool:
+        if self.purpose_editor.handle_event(event):
+            return True
+
+        if event.type != pg.KEYDOWN:
+            return super().handle_event(event)
+
+        # We only handle keydown events from here on.
+        match event.key:
+            case pg.K_j:
+                self.timer_end -= 60 * 5 if pygame_utils.shift_is_pressed(event) else 60
+            case pg.K_k:
+                self.timer_end += 60 * 5 if pygame_utils.shift_is_pressed(event) else 60
+            case number if number in constants.NUMBER_KEYS:
+                new_duration = 60 * pygame_utils.get_number_from_key(number)
+                if pygame_utils.shift_is_pressed(event):
+                    new_duration *= 10
+                self.timer_end = time_utils.compute_timer_end(new_duration, self.start)
+                self.initial_duration = new_duration
+            case pg.K_r:
+                self.timer_end = time_utils.compute_timer_end(self.initial_duration, self.start)
+            case pg.K_t:
+                self.hide_totals = not self.hide_totals
+            case pg.K_h | pg.K_QUESTION:
+                self.push_state(help_screen.HelpScreen())
+            case pg.K_l:
+                self.push_state(purpose_history_screen.PurposeHistoryScreen())
+            case _:
+                return super().handle_event(event)
+        return True
+
+    def layout(self):
+        rect = self.available_rect()
+        height = rect.height
+
+        if self.purpose_editor.editing:
+            if height < 60:
+                layout = {"purpose": 1}
+            elif height < 80:
+                layout = {"purpose": 2, "time": 1}
+            else:
+                layout = {"purpose": 2, "time": 1, "totals": 0.5}
+        else:
+            if height < 60:
+                layout = {"time": 1}
+            elif height < 80:
+                layout = {"purpose": 1, "time": 2}
+            else:
+                layout = {"purpose": 1, "time": 2, "totals": 1}
+
+            if not self.purpose:
+                layout["time"] += layout.pop("purpose", 0)
+
+        if self.hide_totals:
+            layout.pop("totals", None)
+
+        rects = {
+            k: rect
+            for k, rect in zip(layout.keys(), pygame_utils.split_rect(rect, *layout.values()))
+        }
+
+        # Bottom has horizontal layout with [total_time | purpose_time]
+        if total_time_rect := rects.pop("totals", None):
+            rects["total_time"], _, rects["purpose_time"] = pygame_utils.split_rect(
+                total_time_rect, 1, 0.2, 1, horizontal=True
+            )
+
+        return rects
+
+    def draw(self, gfx: help_screen.GFX):
+        super().draw(gfx)
+        layout = self.layout()
+
+        # Render time.
+        remaining = self.timer_end - (time() - self.start)
+        if time_rect := layout.get("time"):
+            color = self.config.color.timer_up if remaining < 0 else self.config.color.timer
+            t = self.config.font.big.render(
+                time_utils.fmt_duration(abs(remaining)),
+                time_rect.size,
+                color,
+                monospaced_time=True,
+            )
+            gfx.blit(t, center=time_rect.center)
+
+        if total_time_rect := layout.get("total_time"):
+            t = self.config.font.normal.render(
+                time_utils.fmt_duration(time() - self.start),
+                total_time_rect.size,
+                self.config.color.total_time,
+                monospaced_time=True,
+            )
+            gfx.blit(t, midleft=total_time_rect.midleft)
+
+        if purpose_time_rect := layout.get("purpose_time"):
+            t = self.config.font.normal.render(
+                time_utils.fmt_duration(time() - self.purpose_start_time),
+                purpose_time_rect.size,
+                self.config.color.purpose,
+                monospaced_time=True,
+            )
+            gfx.blit(t, midright=purpose_time_rect.midright)
+
+        if purpose_rect := layout.get("purpose"):
+            self.purpose_editor.draw(gfx, purpose_rect)
+
+
+class PurposeEditor:
+    def __init__(self, ctx: Context) -> None:
+        super().__init__()
+        self.ctx = ctx
+        self.purpose = ctx.purpose_history[-1].text
+        self.editing = False
+
+    def handle_event(self, event) -> bool:
+        if not self.editing:
+            if event.type == pg.KEYDOWN and event.key == pg.K_RETURN:
+                self.editing = True
+                return True
+            return False
+
+        if event.type == pg.TEXTINPUT:
+            self.purpose += event.text
+            return True
+        elif event.type == pg.KEYDOWN:
+            if event.key == pg.K_BACKSPACE:
+                if event.mod & pg.KMOD_CTRL:
+                    self.purpose = re.sub(r"\S*\s*$", "", self.purpose)
+                else:
+                    self.purpose = self.purpose[:-1]
+                return True
+            elif event.key in (pg.K_RETURN, pg.K_KP_ENTER, pg.K_ESCAPE):
+                self.ctx.set_purpose(self.purpose)
+                self.editing = False
+                return True
+
+        return False
+
+    def draw(self, gfx: GFX, rect: pygame.Rect):
+        t = self.ctx.config.font.normal.render(
+            self.purpose, rect.size, self.ctx.config.color.purpose
+        )
+        r = gfx.blit(t, center=rect.center)
+        if self.editing and (time() % 1) < 0.7:
+            if r.height == 0:
+                r.height = rect.height
+            if r.right >= rect.right:
+                r.right = rect.right - 3
+            pygame.draw.line(gfx.surf, self.ctx.config.color.purpose, r.topright, r.bottomright, 2)

--- a/src/screens/purpose_history_screen.py
+++ b/src/screens/purpose_history_screen.py
@@ -1,0 +1,69 @@
+from time import time
+
+from luckypot.gfx import GFX
+import pygame as pg
+
+from .. import time_utils, pygame_utils
+from .base_screen import PucotiScreen
+
+
+class PurposeHistoryScreen(PucotiScreen):
+    def __init__(self) -> None:
+        super().__init__()
+
+        self.history_lines = 10
+        self.history_scroll = 0  # From the bottom
+        self.show_relative_time = True
+
+    def handle_event(self, event) -> bool:
+        if super().handle_event(event):
+            return True
+
+        if event.type == pg.KEYDOWN:
+            if event.key == pg.K_j:
+                self.history_scroll = max(0, self.history_scroll - 1)
+            elif event.key == pg.K_k:
+                self.history_scroll = min(
+                    len([p for p in self.ctx.purpose_history if p.text]) - self.history_lines,
+                    self.history_scroll + 1,
+                )
+            elif event.key == pg.K_s:
+                self.show_relative_time = not self.show_relative_time
+            else:
+                self.pop_state()
+            return True
+
+        return False
+
+    def draw(self, gfx: GFX):
+        super().draw(gfx)
+
+        rect = self.available_rect()
+        timestamps = [p.timestamp for p in self.ctx.purpose_history] + [time()]
+        rows = [
+            [
+                time_utils.fmt_duration(end_time - p.timestamp),
+                pygame_utils.shorten(p.text, 40),
+                time_utils.fmt_time(p.timestamp, relative=self.show_relative_time),
+            ]
+            for p, end_time in zip(self.ctx.purpose_history, timestamps[1:], strict=True)
+            if p.text
+        ]
+        first_shown = len(rows) - self.history_lines - self.history_scroll
+        last_shown = len(rows) - self.history_scroll
+        hidden_rows = rows[:first_shown] + rows[last_shown:]
+        rows = rows[first_shown:last_shown]
+
+        headers = ["Span", "Purpose [J/K]", "Started [S]"]
+        s = self.config.font.normal.table(
+            [headers] + rows,
+            rect.size,
+            [self.config.color.total_time, self.config.color.purpose, self.config.color.timer],
+            title="History",
+            col_sep=": ",
+            align=[pg.FONT_RIGHT, pg.FONT_LEFT, pg.FONT_RIGHT],
+            title_color=self.config.color.purpose,
+            hidden_rows=hidden_rows,
+            header_line_color=self.config.color.purpose,
+        )
+        gfx.blit(s, center=rect.center)

--- a/src/screens/start_screen.py
+++ b/src/screens/start_screen.py
@@ -1,0 +1,36 @@
+import pygame.locals as pg
+import luckypot
+
+from .base_screen import PucotiScreen
+from . import main_screen
+
+
+class StartScreen(PucotiScreen):
+    def __init__(self):
+        super().__init__()
+        self.timer = 0
+
+    def logic(self):
+        super().logic()
+
+        self.timer += 1
+        if self.timer > 20:
+            self.replace_state(main_screen.MainScreen(self.ctx))
+
+    def handle_events(self, events):
+        super().handle_events(events)
+        for event in events:
+            if event.type == pg.KEYDOWN:
+                self.replace_state(main_screen.MainScreen(self.ctx))
+
+    def draw(self, gfx: luckypot.GFX):
+        super().draw(gfx)
+        r = gfx.surf.get_rect()
+        r.inflate_ip(-10, -10)
+        s = self.ctx.config.font.big.render(
+            "PUCOTI",
+            r.size,
+            self.ctx.config.color.timer,
+            align=pg.FONT_CENTER,
+        )
+        gfx.blit(s, center=r.center)


### PR DESCRIPTION
This is a big refactor, but it should allow us to add more things easily (especially the social / time prediction).
I had to bump `pygame-ce` to 2.5.0, despite #3. @niajane Could you test if it works on your mac, and if not we should probably spend some time trying to debug it. 

If so, one hint might be the value of `$SDL_VIDEODRIVER`, which, when left as `wayland` (on my swaywm machine) reproduces the black screen. This is why I had to set it explicitly to `x11` instead.