### PR TITLE
Ensure window position is valid when toggling size

### DIFF
--- a/src/pucoti/app.py
+++ b/src/pucoti/app.py
@@ -161,6 +161,10 @@ class App(luckypot.App[PucotiScreen]):
     def make_window_big(self):
         """Make the window big."""
         self.window.size = self.config.window.big_size
+        platforms.place_window(
+            self.window,
+            *self.current_window_position,
+        )
 
 
 defaults = PucotiConfig()


### PR DESCRIPTION
When toggling from big to small the window position isn't recalculated, potentially leading to the contents being clipped. This change addresses this by also calling `place_window` in `make_window_big`.